### PR TITLE
fix "Viewing.Extension.ScreenShotManager.js"

### DIFF
--- a/src/client/viewer.components/Viewer.Extensions.Dynamic/Viewing.Extension.ScreenShotManager/Viewing.Extension.ScreenShotManager.js
+++ b/src/client/viewer.components/Viewer.Extensions.Dynamic/Viewing.Extension.ScreenShotManager/Viewing.Extension.ScreenShotManager.js
@@ -64,8 +64,8 @@ class ScreenShotManagerExtension extends ExtensionBase {
 
     this.react.setState({
 
-      height: this.viewer.container.clientHeight,
-      width: this.viewer.container.clientWidth,
+      screenshotHeight: this.viewer.container.clientHeight,
+      screenshotWidth: this.viewer.container.clientWidth,
       items: []
 
     }).then (() => {
@@ -108,20 +108,20 @@ class ScreenShotManagerExtension extends ExtensionBase {
 
     const state = this.react.getState()
 
-    const height = this.floor (state.height)
+    const screenshotHeight = this.floor (state.screenshotHeight)
 
-    const width = this.floor (state.width)
+    const screenshotWidth = this.floor (state.screenshotWidth)
 
     this.viewer.getScreenShot(
-      width, height, (blob) => {
+      screenshotWidth, screenshotHeight, (blob) => {
 
         const state = this.react.getState()
 
         const screenshot = {
           name:  new Date().toString('d/M/yyyy H:mm:ss'),
           id: this.guid(),
-          height,
-          width,
+          screenshotHeight,
+          screenshotWidth,
           blob
         }
 
@@ -212,8 +212,8 @@ class ScreenShotManagerExtension extends ExtensionBase {
     if (this.viewer.container) {
 
       this.react.setState({
-        height: this.viewer.container.clientHeight,
-        width: this.viewer.container.clientWidth
+        screenshotHeight: this.viewer.container.clientHeight,
+        screenshotWidth: this.viewer.container.clientWidth
       })
     }
   }
@@ -292,18 +292,18 @@ class ScreenShotManagerExtension extends ExtensionBase {
           <Label text={'Width (px):'}/>
 
           <ContentEditable
-            onChange={(e) => this.onInputChanged(e, 'width')}
+            onChange={(e) => this.onInputChanged(e, 'screenshotWidth')}
             onKeyDown={(e) => this.onKeyDownNumeric(e)}
             className="size-input"
-            html={state.width}/>
+            html={`${state.screenshotWidth}`}/>
 
           <Label text={'x Height (px):'}/>
 
           <ContentEditable
-            onChange={(e) => this.onInputChanged(e, 'height')}
+            onChange={(e) => this.onInputChanged(e, 'screenshotHeight')}
             onKeyDown={(e) => this.onKeyDownNumeric(e)}
             className="size-input"
-            html={state.height}/>
+            html={`${state.screenshotHeight}`}/>
 
         </div>
       </div>
@@ -321,7 +321,7 @@ class ScreenShotManagerExtension extends ExtensionBase {
     const items = state.items.map((item) => {
 
       const text =
-        `${item.name} [${item.width} x ${item.height}]`
+        `${item.name} [${item.screenshotWidth} x ${item.screenshotHeight}]`
 
       return (
         <div key={item.id} className="item" onClick={


### PR DESCRIPTION
I copied "Viewing.Extension.ScreenShotManager.js". When using this, I found 2 small bugs. 

=============================================================

1: 
`height` and `width` in `state[id]` are used to represent the height and width of the screenshot. But when this extension's panel becomes undocked, `height` and `width` will also be used to represent the panel's height and width. 

If I want to resize the undocked ScreenShotManager panel, it will soon become full-screen and can not be resize to a smaller one, because the panel's height and width become equal to the viewer container's height and width.

So I renamed the `height` and `width` of the screenshot to `screenshotHeight` and `screenshotWidth`.  After renaming, the ScreenShotManager panel could be resized.

=============================================================

2:
In `ContentEditable`, I changed `html={state.screenshotHeight}` into ``html={`${state.screenshotHeight}`}``. It is because that some problems will occur if the type of this html prop is `Number` rather than `String`. The `replace` function of `String` is used in `ContentEditable` but `Number` does not has `replace` function. There will be some errors if the html prop is `Number`.

Also, if the type of html prop is `Number`, a warning will show in console:

    Warning: Failed prop type: Invalid prop `html` of type `number` supplied to `ContentEditable`, expected `string`.
    in ContentEditable (created by ViewerConfigurator)
    in ViewerConfigurator (created by DatabaseView)
    ......

This seems no longer a problem if using new version of `react-contenteditable` (`ContentEditable`). But now the ScreenShotManager in https://forge-rcdb.autodesk.io/ does not work because of that. So I think it is better to mannually change the type into `String`.

In https://forge-rcdb.autodesk.io/, if I use ScreenShotManager, what the console shows is:

    Uncaught (in promise) TypeError: e.replace is not a function
    at i (configurator.531122013159909c62f5.min.js:1)
    at t.shouldComponentUpdate (configurator.531122013159909c62f5.min.js:1)
    ......