### PR TITLE
modify "onResize" in "Viewer.Configurator.js"

### DIFF
--- a/src/client/viewer.components/Viewer.Configurator/Viewer.Configurator.js
+++ b/src/client/viewer.components/Viewer.Configurator/Viewer.Configurator.js
@@ -275,6 +275,7 @@ class ViewerConfigurator extends BaseComponent {
           renderExtension: extension
         }).then(() => {
 
+          this.onResize()
           resolve ()
         })
 
@@ -306,6 +307,7 @@ class ViewerConfigurator extends BaseComponent {
           paneExtStyle: { display: 'none' }
         })
 
+        this.onResize()
         resolve ()
 
       }, 250)
@@ -965,6 +967,17 @@ class ViewerConfigurator extends BaseComponent {
         this.state.renderExtension.onResize()
       }
     }
+
+    if(this.state.viewerPanels){
+      this.state.viewerPanels.forEach(
+        (viewerPanel)=>{
+          if(viewerPanel.renderable && viewerPanel.renderable.onResize){
+            viewerPanel.renderable.onResize()
+          }
+        }
+      )
+    }
+
   }
 
   /////////////////////////////////////////////////////////


### PR DESCRIPTION
I copied "Viewer.Configurator.js" and "Viewing.Extension.ScreenShotManager.js". Sometimes, the `height` and `width` of the screenshot did not change after the `viewer container` resized. So I did some modifications in "Viewer.Configurator.js".

================================================

1:
Before modification, as long as the screenshotManager panel was `undocked`, the `onResize` function of this extension would not be triggered even though the `window` or `viewer container` resized. It was because that `Configurator` only called the `onResize` functions of the "this.state.renderExtension". And for those extensions in "this.state.viewerPanels", their `onResize` function would not be called. 

But I think these `onResize` should also be called. For example, when the `viewer container` resizes, even if the screenshotManager is `undocked`, it still need to use `onResize` function to track the height and width of the `viewer container`. 

So I add some codes to trigger every "viewerPanel.renderable.onResize" when the `viewer container` resizes. And now the screenshotManager can show and utilize correct height and width of the `viewer container` even if the screenshotManager panel is `undocked`.

================================================

2:
Before modification, the animation of the "pushRenderExtension" or "popRenderExtension" would change the height and width of the `viewer container`. However, the animation would not trigger the `onResize` function of `Configurator`. 

So I add "this.onResize()" after the "pushRenderExtension" or "popRenderExtension". In this way, the `onResize` function can be called after the animation ended.   

I did some tries and decided to add "this.onResize()" after pushing or poping an extension. If "this.onResize()" is called directly after the animation (e.g.,  `    return this.animate (
      animPeriod, easingFn, update).then(()=>{
        this.onResize()
      })`) , it will have no effects because at that moment the state has not been set and there are no extensions in  "this.state.renderExtension". 

With these modifications, the screenshotManager can show and utilize the correct height and width of the `viewer container` after the animation ends.